### PR TITLE
Support Groestl hash in checksum of Base58Check

### DIFF
--- a/address.go
+++ b/address.go
@@ -297,7 +297,7 @@ func (a *AddressPubKeyHash) ScriptAddress() []byte {
 // IsForNet returns whether or not the pay-to-pubkey-hash address is associated
 // with the passed bitcoin network.
 func (a *AddressPubKeyHash) IsForNet(net *chaincfg.Params) bool {
-	return bytes.Equal(a.netID, net.PubKeyHashAddrID) && a.cksumHasher == net.Base58CksumHasher
+	return bytes.Equal(a.netID, net.PubKeyHashAddrID)
 }
 
 // String returns a human-readable string for the pay-to-pubkey-hash address.
@@ -368,7 +368,7 @@ func (a *AddressScriptHash) ScriptAddress() []byte {
 // IsForNet returns whether or not the pay-to-script-hash address is associated
 // with the passed bitcoin network.
 func (a *AddressScriptHash) IsForNet(net *chaincfg.Params) bool {
-	return bytes.Equal(a.netID, net.ScriptHashAddrID) && a.cksumHasher == net.Base58CksumHasher
+	return bytes.Equal(a.netID, net.ScriptHashAddrID)
 }
 
 // String returns a human-readable string for the pay-to-script-hash address.
@@ -481,7 +481,7 @@ func (a *AddressPubKey) ScriptAddress() []byte {
 // IsForNet returns whether or not the pay-to-pubkey address is associated
 // with the passed bitcoin network.
 func (a *AddressPubKey) IsForNet(net *chaincfg.Params) bool {
-	return bytes.Equal(a.pubKeyHashID, net.PubKeyHashAddrID) && a.cksumHasher == net.Base58CksumHasher
+	return bytes.Equal(a.pubKeyHashID, net.PubKeyHashAddrID)
 }
 
 // String returns the hex-encoded human-readable string for the pay-to-pubkey

--- a/base58/base58check.go
+++ b/base58/base58check.go
@@ -7,6 +7,15 @@ package base58
 import (
 	"crypto/sha256"
 	"errors"
+	"github.com/Groestlcoin/go-groestl-hash/groestl"
+)
+
+type CksumHasher int
+
+// Hash function types for checksum calculation
+const (
+	Sha256D     CksumHasher = iota // Double SHA256
+	Groestl512D                    // Double Groestl512
 )
 
 // ErrChecksum indicates that the checksum of a check-encoded string does not verify against
@@ -16,26 +25,40 @@ var ErrChecksum = errors.New("checksum error")
 // ErrInvalidFormat indicates that the check-encoded string has an invalid format.
 var ErrInvalidFormat = errors.New("invalid format: version and/or checksum bytes missing")
 
-// checksum: first four bytes of sha256^2
-func checksum(input []byte) (cksum [4]byte) {
-	h := sha256.Sum256(input)
-	h2 := sha256.Sum256(h[:])
-	copy(cksum[:], h2[:4])
+// checksum: first four bytes of hash^2
+func checksum(input []byte, hash CksumHasher) (cksum [4]byte) {
+	switch hash {
+	case Sha256D:
+		h := sha256.Sum256(input)
+		h2 := sha256.Sum256(h[:])
+		copy(cksum[:], h2[:4])
+	case Groestl512D:
+		var h1, h2 [64]byte
+		g := groestl.New()
+		g.Write(input)
+		g.Close(h1[:], 0, 0)
+		g.Write(h1[:])
+		g.Close(h2[:], 0, 0)
+		copy(cksum[:], h2[:4])
+	default:
+		// Should never happen
+		panic("BUG! Not all CksumHasher values are implemented.")
+	}
 	return
 }
 
 // CheckEncode prepends a version byte and appends a four byte checksum.
-func CheckEncode(input, version []byte) string {
+func CheckEncode(input, version []byte, hash CksumHasher) string {
 	b := make([]byte, 0, len(version)+len(input)+4)
 	b = append(b, version[:]...)
 	b = append(b, input[:]...)
-	cksum := checksum(b)
+	cksum := checksum(b, hash)
 	b = append(b, cksum[:]...)
 	return Encode(b)
 }
 
 // CheckDecode decodes a string that was encoded with CheckEncode and verifies the checksum.
-func CheckDecode(input string, versionLen uint8) (result, version []byte, err error) {
+func CheckDecode(input string, versionLen uint8, hash CksumHasher) (result, version []byte, err error) {
 	decoded := Decode(input)
 	if len(decoded) < 5 {
 		return nil, nil, ErrInvalidFormat
@@ -43,7 +66,7 @@ func CheckDecode(input string, versionLen uint8) (result, version []byte, err er
 	version = decoded[:versionLen]
 	var cksum [4]byte
 	copy(cksum[:], decoded[len(decoded)-4:])
-	if checksum(decoded[:len(decoded)-4]) != cksum {
+	if checksum(decoded[:len(decoded)-4], hash) != cksum {
 		return nil, nil, ErrChecksum
 	}
 	payload := decoded[versionLen : len(decoded)-4]

--- a/base58/example_test.go
+++ b/base58/example_test.go
@@ -41,7 +41,7 @@ func ExampleEncode() {
 func ExampleCheckDecode() {
 	// Decode an example Base58Check encoded data.
 	encoded := "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
-	decoded, version, err := base58.CheckDecode(encoded, 1)
+	decoded, version, err := base58.CheckDecode(encoded, 1, base58.Sha256D)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -61,7 +61,7 @@ func ExampleCheckDecode() {
 func ExampleCheckEncode() {
 	// Encode example data with the Base58Check encoding scheme.
 	data := []byte("Test data")
-	encoded := base58.CheckEncode(data, []byte{0})
+	encoded := base58.CheckEncode(data, []byte{0}, base58.Sha256D)
 
 	// Show the encoded data.
 	fmt.Println("Encoded Data:", encoded)

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/jakm/btcutil/base58"
 )
 
 // These variables are the chain proof-of-work limit parameters for each default
@@ -214,6 +215,8 @@ type Params struct {
 	WitnessPubKeyHashAddrID []byte // First n bytes of a P2WPKH address
 	WitnessScriptHashAddrID []byte // First n bytes of a P2WSH address
 
+	Base58CksumHasher base58.CksumHasher // Hash used for address checksum
+
 	// BIP32 hierarchical deterministic extended key magics
 	HDPrivateKeyID [4]byte
 	HDPublicKeyID  [4]byte
@@ -314,6 +317,7 @@ var MainNetParams = Params{
 	PrivateKeyID:            []byte{0x80}, // starts with 5 (uncompressed) or K (compressed)
 	WitnessPubKeyHashAddrID: []byte{0x06}, // starts with p2
 	WitnessScriptHashAddrID: []byte{0x0A}, // starts with 7Xh
+	Base58CksumHasher:       base58.Sha256D,
 
 	// BIP32 hierarchical deterministic extended key magics
 	HDPrivateKeyID: [4]byte{0x04, 0x88, 0xad, 0xe4}, // starts with xprv
@@ -385,10 +389,11 @@ var RegressionNetParams = Params{
 	Bech32HRPSegwit: "bcrt", // always bcrt for reg test net
 
 	// Address encoding magics
-	AddressMagicLen:  1,
-	PubKeyHashAddrID: []byte{0x6f}, // starts with m or n
-	ScriptHashAddrID: []byte{0xc4}, // starts with 2
-	PrivateKeyID:     []byte{0xef}, // starts with 9 (uncompressed) or c (compressed)
+	AddressMagicLen:   1,
+	PubKeyHashAddrID:  []byte{0x6f}, // starts with m or n
+	ScriptHashAddrID:  []byte{0xc4}, // starts with 2
+	PrivateKeyID:      []byte{0xef}, // starts with 9 (uncompressed) or c (compressed)
+	Base58CksumHasher: base58.Sha256D,
 
 	// BIP32 hierarchical deterministic extended key magics
 	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
@@ -483,6 +488,7 @@ var TestNet3Params = Params{
 	WitnessPubKeyHashAddrID: []byte{0x03}, // starts with QW
 	WitnessScriptHashAddrID: []byte{0x28}, // starts with T7n
 	PrivateKeyID:            []byte{0xef}, // starts with 9 (uncompressed) or c (compressed)
+	Base58CksumHasher:       base58.Sha256D,
 
 	// BIP32 hierarchical deterministic extended key magics
 	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
@@ -564,6 +570,7 @@ var SimNetParams = Params{
 	PrivateKeyID:            []byte{0x64}, // starts with 4 (uncompressed) or F (compressed)
 	WitnessPubKeyHashAddrID: []byte{0x19}, // starts with Gg
 	WitnessScriptHashAddrID: []byte{0x28}, // starts with ?
+	Base58CksumHasher:       base58.Sha256D,
 
 	// BIP32 hierarchical deterministic extended key magics
 	HDPrivateKeyID: [4]byte{0x04, 0x20, 0xb9, 0x00}, // starts with sprv


### PR DESCRIPTION
This patch adds support for Groestl hash in checksum of Base58Check algorithm and adds new field to `chaincfg.Params` to select which algorithm coin uses. Tests are updated to include several cases with Groestl hash.

This PR will allow adding Groestlcoin support to blockbook without duplicating all address decode/generation functions. It also will be useful for addition of other coins supported by Trezor which use different checksum hasher (eg. decred, smartcash). They will need to add just few lines to `base58/base58check.go`.